### PR TITLE
Better error message

### DIFF
--- a/lib/exchange/external_api/base.rb
+++ b/lib/exchange/external_api/base.rb
@@ -131,7 +131,7 @@ module Exchange
           rate_from   = rates[from]
           rate_to     = rates[to]
           
-          test_for_rates_and_raise_if_nil rate_from, rate_to, opts[:at]
+          test_for_rates_and_raise_if_nil [from, rate_from], [to, rate_to], opts[:at]
           
           rate_to / rate_from
         end
@@ -169,7 +169,7 @@ module Exchange
       # @raise [NoRateError] An error indicating that there is no rate present when there is no rate present
       #
       def test_for_rates_and_raise_if_nil rate_from, rate_to, time=nil
-        raise NoRateError.new("No rates where found for #{rate_from} to #{rate_to} #{'at ' + time.to_s if time}") unless rate_from && rate_to
+        raise NoRateError.new("No rates where found for #{rate_from[0]} to #{rate_to[0]} #{'at ' + time.to_s if time}") unless rate_from[1] && rate_to[1]
       end
       
       protected


### PR DESCRIPTION
Ensures that the error raised contains the `from` and `to` currency codes.

Prior to this change, the error raised would not contain the from & to currency codes, eg:
`Exchange::NoRateError: No rates where found for  to 1.380024 at Sun Aug 01 00:00:00 +1200 2010`

This is because the method only raises an error when `from_code` and `to_code` are `nil`. This is an perfectly fine way to raise the error, but it also means that those `nil` values are getting used in the error message string. This commit supplies the original from & to codes as well, so they they may be used in the error message.

This is a fairly ugly and direct way to fix this issue, so feel free to take it or leave it -- but please do add the currency codes to the error message one way or another.
